### PR TITLE
FIX: Drop NaN onset rows in events.tsv

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
           python -m pip install build twine
       - run: python -m build --sdist --wheel
       - run: twine check --strict dist/*
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@v7
         with:
           name: dist
           path: dist
@@ -48,7 +48,7 @@ jobs:
       name: pypi
       url: https://pypi.org/p/mne-bids
     steps:
-      - uses: actions/download-artifact@v7
+      - uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -359,7 +359,7 @@ jobs:
       run: |
         make build-doc
     - name: Upload artifacts
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@v7
       with:
         name: documentation
         path: doc/_build/html

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.2
+    rev: v0.15.4
     hooks:
       - id: ruff
         name: ruff mne_bids/

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -55,6 +55,7 @@ Detailed list of changes
 - Fix :func:`mne_bids.BIDSPath.find_matching_sidecar` to search for sidecar files at the dataset root level per the BIDS inheritance principle, by `Bruno Aristimunha`_ (:gh:`1508`)
 - Reinstate the requirement for ``coordsystem.json`` whenever ``electrodes.tsv`` is present (including EMG), by `Bruno Aristimunha`_ (:gh:`1508`)
 - Fix :func:`read_raw_bids` ignoring ``electrodes.tsv`` when ``EEGCoordinateUnits`` is ``"n/a"`` by inferring the unit from coordinate magnitudes, and synthesize approximate fiducials for ``ctf_head`` montages to enable the coordinate transform to ``head`` frame, by `Bruno Aristimunha`_ (:gh:`1506`)
+- Improve :func:`mne_bids.read_raw_bids` handling when ``electrodes.tsv`` exists without ``coordsystem.json``: keep strict failure for iEEG, and for EEG/MEG emit a warning and continue without applying a montage, by `Bruno Aristimunha`_
 
 ⚕️ Code health
 ^^^^^^^^^^^^^^

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -56,6 +56,7 @@ Detailed list of changes
 - Reinstate the requirement for ``coordsystem.json`` whenever ``electrodes.tsv`` is present (including EMG), by `Bruno Aristimunha`_ (:gh:`1508`)
 - Fix :func:`read_raw_bids` ignoring ``electrodes.tsv`` when ``EEGCoordinateUnits`` is ``"n/a"`` by inferring the unit from coordinate magnitudes, and synthesize approximate fiducials for ``ctf_head`` montages to enable the coordinate transform to ``head`` frame, by `Bruno Aristimunha`_ (:gh:`1506`)
 - Improve :func:`mne_bids.read_raw_bids` handling when ``electrodes.tsv`` exists without ``coordsystem.json``: keep strict failure for iEEG, and for EEG/MEG emit a warning and continue without applying a montage, by `Bruno Aristimunha`_
+- :func:`mne_bids.read_raw_bids` now drops events with ``"nan"`` or ``"NaN"`` onset values in ``events.tsv``, matching the existing handling of ``"n/a"`` onsets. This prevents silent corruption from EEGLAB exports, by `Bruno Aristimunha`_ (:gh:`XXXX`)
 
 ⚕️ Code health
 ^^^^^^^^^^^^^^

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -640,9 +640,9 @@ def events_file_to_annotation_kwargs(events_fname: str | Path, *, verbose=None) 
     logger.info(f"Reading events from {events_fname}.")
     events_dict = _from_tsv(events_fname)
 
-    # drop events where onset is n/a; we can't annotate them and thus don't need entries
-    # for them in event_id either
-    events_dict = _drop(events_dict, "n/a", "onset")
+    # drop events where onset is n/a or NaN; we can't annotate them and thus don't need
+    # entries for them in event_id either. "nan"/"NaN" values are common in EEGLAB exports.
+    events_dict = _drop(events_dict, ["n/a", "nan", "NaN", ""], "onset")
 
     # Get event descriptions. Use `trial_type` column if available.
     if "trial_type" in events_dict:

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -640,8 +640,9 @@ def events_file_to_annotation_kwargs(events_fname: str | Path, *, verbose=None) 
     logger.info(f"Reading events from {events_fname}.")
     events_dict = _from_tsv(events_fname)
 
-    # drop events where onset is n/a or NaN; we can't annotate them and thus don't need
-    # entries for them in event_id either. "nan"/"NaN" values are common in EEGLAB exports.
+    # Drop events where onset is n/a, NaN, or empty; we can't annotate
+    # them and thus don't need entries for them in event_id either.
+    # "nan"/"NaN" values are common in EEGLAB exports.
     events_dict = _drop(events_dict, ["n/a", "nan", "NaN", ""], "onset")
 
     # Get event descriptions. Use `trial_type` column if available.

--- a/mne_bids/tests/test_read.py
+++ b/mne_bids/tests/test_read.py
@@ -2036,3 +2036,18 @@ def test_events_file_to_annotation_kwargs(tmp_path):
         np.sort(np.unique(ev_kwargs_default["description"])),
         np.sort(dext_f["value"].unique()),
     )
+
+    # ---------------- filtering out NaN onset values (EEGLAB exports) ------
+    dext2 = df.copy()
+    dext2 = dext2.assign(
+        value=dext2.trial_type.map({"start_experiment": 1, "show_stimulus": 2}),
+        duration=1.0,
+    )
+    # Set some onsets to "nan" (as EEGLAB exports produce)
+    dext2.loc[0, "onset"] = "nan"
+    dext2.loc[1, "onset"] = "NaN"
+    dext2.to_csv(tmp_tsv_file, sep="\t", index=False)
+
+    ev_kwargs_nan = events_file_to_annotation_kwargs(events_fname=tmp_tsv_file)
+    # The two rows with nan/NaN onsets should have been dropped
+    assert len(ev_kwargs_nan["onset"]) == len(dext2) - 2


### PR DESCRIPTION
## Summary

- `events_file_to_annotation_kwargs` drops `"n/a"` onsets but not `"nan"`/`"NaN"` (common in EEGLAB exports), causing silent corruption when converted to float.
- Extend `_drop` call to also filter `"nan"`, `"NaN"`, and `""` values.
- Discovered processing OpenNeuro datasets during batch ingestion with eegdash.

Closes #23

## Test plan

- [ ] Added test case with `"nan"` and `"NaN"` onset values
- [ ] Run `make pep` and `make test`