### PR TITLE
FIX: Replace assert with ValueError in copyfile_eeglab

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
           python -m pip install build twine
       - run: python -m build --sdist --wheel
       - run: twine check --strict dist/*
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@v7
         with:
           name: dist
           path: dist
@@ -48,7 +48,7 @@ jobs:
       name: pypi
       url: https://pypi.org/p/mne-bids
     steps:
-      - uses: actions/download-artifact@v7
+      - uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -359,7 +359,7 @@ jobs:
       run: |
         make build-doc
     - name: Upload artifacts
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@v7
       with:
         name: documentation
         path: doc/_build/html

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.2
+    rev: v0.15.4
     hooks:
       - id: ruff
         name: ruff mne_bids/

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -55,6 +55,7 @@ Detailed list of changes
 - Fix :func:`mne_bids.BIDSPath.find_matching_sidecar` to search for sidecar files at the dataset root level per the BIDS inheritance principle, by `Bruno Aristimunha`_ (:gh:`1508`)
 - Reinstate the requirement for ``coordsystem.json`` whenever ``electrodes.tsv`` is present (including EMG), by `Bruno Aristimunha`_ (:gh:`1508`)
 - Fix :func:`read_raw_bids` ignoring ``electrodes.tsv`` when ``EEGCoordinateUnits`` is ``"n/a"`` by inferring the unit from coordinate magnitudes, and synthesize approximate fiducials for ``ctf_head`` montages to enable the coordinate transform to ``head`` frame, by `Bruno Aristimunha`_ (:gh:`1506`)
+- Improve :func:`mne_bids.read_raw_bids` handling when ``electrodes.tsv`` exists without ``coordsystem.json``: keep strict failure for iEEG, and for EEG/MEG emit a warning and continue without applying a montage, by `Bruno Aristimunha`_
 
 ⚕️ Code health
 ^^^^^^^^^^^^^^

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -60,6 +60,6 @@ Detailed list of changes
 ⚕️ Code health
 ^^^^^^^^^^^^^^
 
-- None yet
+- Replace ``assert`` with ``ValueError`` for data validation in :func:`mne_bids.copyfiles.copyfile_eeglab`, ensuring the check is not silently skipped under ``python -O``, by `Bruno Aristimunha`_ (:gh:`XXXX`)
 
 :doc:`Find out what was new in previous releases <whats_new_previous_releases>`

--- a/mne_bids/copyfiles.py
+++ b/mne_bids/copyfiles.py
@@ -635,7 +635,8 @@ def copyfile_eeglab(src, dest):
     if has_fdt_link:
         fdt_fname = eeg["data"][0, 0][0]
 
-        assert fdt_fname.endswith(".fdt"), f"Unexpected fdt name: {fdt_fname}"
+        if not fdt_fname.endswith(".fdt"):
+            raise ValueError(f"Unexpected fdt name: {fdt_fname}")
         head, _ = op.split(src)
         fdt_path = op.join(head, fdt_fname)
 


### PR DESCRIPTION
## Summary

- `copyfiles.py:638` uses `assert fdt_fname.endswith(".fdt")` for data validation, which is disabled under `python -O`.
- Replace with `if not ...: raise ValueError(...)` for reliable validation.

Closes #22

## Test plan

- [ ] Run `make pep` and `make test`