### PR TITLE
FIX: Auto-retry EEGLAB .set files with latin-1 codec

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
           python -m pip install build twine
       - run: python -m build --sdist --wheel
       - run: twine check --strict dist/*
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@v7
         with:
           name: dist
           path: dist
@@ -48,7 +48,7 @@ jobs:
       name: pypi
       url: https://pypi.org/p/mne-bids
     steps:
-      - uses: actions/download-artifact@v7
+      - uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -359,7 +359,7 @@ jobs:
       run: |
         make build-doc
     - name: Upload artifacts
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@v7
       with:
         name: documentation
         path: doc/_build/html

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.2
+    rev: v0.15.4
     hooks:
       - id: ruff
         name: ruff mne_bids/

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -55,6 +55,7 @@ Detailed list of changes
 - Fix :func:`mne_bids.BIDSPath.find_matching_sidecar` to search for sidecar files at the dataset root level per the BIDS inheritance principle, by `Bruno Aristimunha`_ (:gh:`1508`)
 - Reinstate the requirement for ``coordsystem.json`` whenever ``electrodes.tsv`` is present (including EMG), by `Bruno Aristimunha`_ (:gh:`1508`)
 - Fix :func:`read_raw_bids` ignoring ``electrodes.tsv`` when ``EEGCoordinateUnits`` is ``"n/a"`` by inferring the unit from coordinate magnitudes, and synthesize approximate fiducials for ``ctf_head`` montages to enable the coordinate transform to ``head`` frame, by `Bruno Aristimunha`_ (:gh:`1506`)
+- Improve :func:`mne_bids.read_raw_bids` handling when ``electrodes.tsv`` exists without ``coordsystem.json``: keep strict failure for iEEG, and for EEG/MEG emit a warning and continue without applying a montage, by `Bruno Aristimunha`_
 
 ⚕️ Code health
 ^^^^^^^^^^^^^^

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -56,6 +56,7 @@ Detailed list of changes
 - Reinstate the requirement for ``coordsystem.json`` whenever ``electrodes.tsv`` is present (including EMG), by `Bruno Aristimunha`_ (:gh:`1508`)
 - Fix :func:`read_raw_bids` ignoring ``electrodes.tsv`` when ``EEGCoordinateUnits`` is ``"n/a"`` by inferring the unit from coordinate magnitudes, and synthesize approximate fiducials for ``ctf_head`` montages to enable the coordinate transform to ``head`` frame, by `Bruno Aristimunha`_ (:gh:`1506`)
 - Improve :func:`mne_bids.read_raw_bids` handling when ``electrodes.tsv`` exists without ``coordsystem.json``: keep strict failure for iEEG, and for EEG/MEG emit a warning and continue without applying a montage, by `Bruno Aristimunha`_
+- :func:`mne_bids.read_raw_bids` now automatically retries reading EEGLAB ``.set`` files with ``uint16_codec="latin-1"`` when a ``TypeError("buffer is too small")`` is raised, fixing a common issue with non-ASCII channel labels, by `Bruno Aristimunha`_ (:gh:`XXXX`)
 
 ⚕️ Code health
 ^^^^^^^^^^^^^^

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -97,7 +97,22 @@ def _read_raw(
                 f"this format."
             )
         raw_path = Path(raw_path)
-        raw = reader[ext](raw_path, verbose=verbose, **kwargs)
+        try:
+            raw = reader[ext](raw_path, verbose=verbose, **kwargs)
+        except TypeError as exc:
+            if ext == ".set" and "buffer is too small" in str(exc):
+                warn(
+                    "EEGLAB character encoding error detected. "
+                    'Retrying with uint16_codec="latin-1".'
+                )
+                raw = reader[ext](
+                    raw_path,
+                    verbose=verbose,
+                    uint16_codec="latin-1",
+                    **kwargs,
+                )
+            else:
+                raise
 
     # NWB is allowed, but not yet implemented
     elif ext == ".nwb":


### PR DESCRIPTION
## Summary

- When EEGLAB `.set` files have Latin-1 encoded char fields, `scipy.io.loadmat` fails with `TypeError("buffer is too small")`. Users must manually pass `extra_params={"uint16_codec": "latin-1"}`.
- Catch this specific `TypeError` for `.set` files in `_read_raw` and auto-retry with `uint16_codec="latin-1"`, emitting a warning.
- `copyfiles.py:614` already has `uint16_codec = None` showing awareness of this parameter.
- Discovered processing OpenNeuro datasets during batch ingestion with eegdash.

Closes #21

## Test plan

- [ ] Run `make pep` and `make test`