### PR TITLE
FIX: Fall back to latin-1 encoding for non-UTF-8 TSV files

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
           python -m pip install build twine
       - run: python -m build --sdist --wheel
       - run: twine check --strict dist/*
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@v7
         with:
           name: dist
           path: dist
@@ -48,7 +48,7 @@ jobs:
       name: pypi
       url: https://pypi.org/p/mne-bids
     steps:
-      - uses: actions/download-artifact@v7
+      - uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -359,7 +359,7 @@ jobs:
       run: |
         make build-doc
     - name: Upload artifacts
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@v7
       with:
         name: documentation
         path: doc/_build/html

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.2
+    rev: v0.15.4
     hooks:
       - id: ruff
         name: ruff mne_bids/

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -55,6 +55,7 @@ Detailed list of changes
 - Fix :func:`mne_bids.BIDSPath.find_matching_sidecar` to search for sidecar files at the dataset root level per the BIDS inheritance principle, by `Bruno Aristimunha`_ (:gh:`1508`)
 - Reinstate the requirement for ``coordsystem.json`` whenever ``electrodes.tsv`` is present (including EMG), by `Bruno Aristimunha`_ (:gh:`1508`)
 - Fix :func:`read_raw_bids` ignoring ``electrodes.tsv`` when ``EEGCoordinateUnits`` is ``"n/a"`` by inferring the unit from coordinate magnitudes, and synthesize approximate fiducials for ``ctf_head`` montages to enable the coordinate transform to ``head`` frame, by `Bruno Aristimunha`_ (:gh:`1506`)
+- Improve :func:`mne_bids.read_raw_bids` handling when ``electrodes.tsv`` exists without ``coordsystem.json``: keep strict failure for iEEG, and for EEG/MEG emit a warning and continue without applying a montage, by `Bruno Aristimunha`_
 
 ⚕️ Code health
 ^^^^^^^^^^^^^^

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -56,6 +56,7 @@ Detailed list of changes
 - Reinstate the requirement for ``coordsystem.json`` whenever ``electrodes.tsv`` is present (including EMG), by `Bruno Aristimunha`_ (:gh:`1508`)
 - Fix :func:`read_raw_bids` ignoring ``electrodes.tsv`` when ``EEGCoordinateUnits`` is ``"n/a"`` by inferring the unit from coordinate magnitudes, and synthesize approximate fiducials for ``ctf_head`` montages to enable the coordinate transform to ``head`` frame, by `Bruno Aristimunha`_ (:gh:`1506`)
 - Improve :func:`mne_bids.read_raw_bids` handling when ``electrodes.tsv`` exists without ``coordsystem.json``: keep strict failure for iEEG, and for EEG/MEG emit a warning and continue without applying a montage, by `Bruno Aristimunha`_
+- TSV reading now falls back to ``latin-1`` encoding when ``utf-8`` decoding fails, with a warning. This fixes crashes on datasets that contain non-ASCII characters like ``µ`` (micro-sign) in ``channels.tsv`` or other sidecar files, by `Bruno Aristimunha`_ (:gh:`XXXX`)
 
 ⚕️ Code health
 ^^^^^^^^^^^^^^

--- a/mne_bids/tests/test_tsv_handler.py
+++ b/mne_bids/tests/test_tsv_handler.py
@@ -119,3 +119,15 @@ def test_drop_different_types():
     result = _drop(data, values=values_to_drop, column=column)
     for value in values_to_drop:
         assert value not in result
+
+
+def test_from_tsv_latin1_fallback(tmp_path):
+    """Test that _from_tsv falls back to latin-1 for non-UTF-8 files."""
+    # Write a TSV with a latin-1 encoded micro-sign (µ = 0xB5)
+    tsv_path = tmp_path / "channels.tsv"
+    tsv_path.write_bytes(b"name\tunits\nEEG1\t\xb5V\n")
+
+    with pytest.warns(RuntimeWarning, match="not UTF-8 encoded"):
+        d = _from_tsv(tsv_path)
+    assert d["name"] == ["EEG1"]
+    assert "V" in d["units"][0]  # µV after decoding

--- a/mne_bids/tsv_handler.py
+++ b/mne_bids/tsv_handler.py
@@ -147,9 +147,28 @@ def _from_tsv(fname, dtypes=None):
     """
     from .utils import warn  # avoid circular import
 
-    data = np.loadtxt(
-        fname, dtype=str, delimiter="\t", ndmin=2, comments=None, encoding="utf-8-sig"
-    )
+    try:
+        data = np.loadtxt(
+            fname,
+            dtype=str,
+            delimiter="\t",
+            ndmin=2,
+            comments=None,
+            encoding="utf-8-sig",
+        )
+    except UnicodeDecodeError:
+        warn(
+            f"TSV file {fname} is not UTF-8 encoded. "
+            f"Falling back to latin-1 encoding."
+        )
+        data = np.loadtxt(
+            fname,
+            dtype=str,
+            delimiter="\t",
+            ndmin=2,
+            comments=None,
+            encoding="latin-1",
+        )
     # Handle empty files - data may be empty or only have a header
     if data.size == 0:
         warn(f"TSV file is empty: '{fname}'")


### PR DESCRIPTION
## Summary

- `_from_tsv` uses `encoding="utf-8-sig"` which crashes on Latin-1 encoded TSVs containing chars like `µ` (micro-sign, common in European datasets).
- Add `try/except UnicodeDecodeError` to fall back to `latin-1` encoding with a warning.
- Related to open issue mne-tools/mne-bids#1530 and PR mne-tools/mne-bids#1531.
- Discovered processing OpenNeuro datasets during batch ingestion with eegdash.

Closes #20

## Test plan

- [ ] Added test with latin-1 encoded micro-sign in TSV
- [ ] Run `make pep` and `make test`