### PR TITLE
FIX: Pass on_split_missing='warn' for split FIF files

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
           python -m pip install build twine
       - run: python -m build --sdist --wheel
       - run: twine check --strict dist/*
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@v7
         with:
           name: dist
           path: dist
@@ -48,7 +48,7 @@ jobs:
       name: pypi
       url: https://pypi.org/p/mne-bids
     steps:
-      - uses: actions/download-artifact@v7
+      - uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -359,7 +359,7 @@ jobs:
       run: |
         make build-doc
     - name: Upload artifacts
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@v7
       with:
         name: documentation
         path: doc/_build/html

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.2
+    rev: v0.15.4
     hooks:
       - id: ruff
         name: ruff mne_bids/

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -55,6 +55,7 @@ Detailed list of changes
 - Fix :func:`mne_bids.BIDSPath.find_matching_sidecar` to search for sidecar files at the dataset root level per the BIDS inheritance principle, by `Bruno Aristimunha`_ (:gh:`1508`)
 - Reinstate the requirement for ``coordsystem.json`` whenever ``electrodes.tsv`` is present (including EMG), by `Bruno Aristimunha`_ (:gh:`1508`)
 - Fix :func:`read_raw_bids` ignoring ``electrodes.tsv`` when ``EEGCoordinateUnits`` is ``"n/a"`` by inferring the unit from coordinate magnitudes, and synthesize approximate fiducials for ``ctf_head`` montages to enable the coordinate transform to ``head`` frame, by `Bruno Aristimunha`_ (:gh:`1506`)
+- Improve :func:`mne_bids.read_raw_bids` handling when ``electrodes.tsv`` exists without ``coordsystem.json``: keep strict failure for iEEG, and for EEG/MEG emit a warning and continue without applying a montage, by `Bruno Aristimunha`_
 
 ⚕️ Code health
 ^^^^^^^^^^^^^^

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -56,6 +56,7 @@ Detailed list of changes
 - Reinstate the requirement for ``coordsystem.json`` whenever ``electrodes.tsv`` is present (including EMG), by `Bruno Aristimunha`_ (:gh:`1508`)
 - Fix :func:`read_raw_bids` ignoring ``electrodes.tsv`` when ``EEGCoordinateUnits`` is ``"n/a"`` by inferring the unit from coordinate magnitudes, and synthesize approximate fiducials for ``ctf_head`` montages to enable the coordinate transform to ``head`` frame, by `Bruno Aristimunha`_ (:gh:`1506`)
 - Improve :func:`mne_bids.read_raw_bids` handling when ``electrodes.tsv`` exists without ``coordsystem.json``: keep strict failure for iEEG, and for EEG/MEG emit a warning and continue without applying a montage, by `Bruno Aristimunha`_
+- :func:`mne_bids.read_raw_bids` now passes ``on_split_missing="warn"`` when reading split FIF files, allowing partial data loading when not all split files are available, instead of crashing. This addresses the long-standing ``FIXME`` in ``path.py``, by `Bruno Aristimunha`_ (:gh:`XXXX`)
 
 ⚕️ Code health
 ^^^^^^^^^^^^^^

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -902,8 +902,9 @@ class BIDSPath:
                 # get matching BIDSPaths inside the bids root
                 matching_paths = _get_matching_bidspaths_from_filesystem(self)
 
-                # FIXME This will break
-                # FIXME e.g. with FIFF data split across multiple files.
+                # NOTE: FIFF data split across multiple files is partially
+                # handled: read_raw_bids passes on_split_missing="warn" so that
+                # MNE can load the first split even if later splits are absent.
                 # if extension is not specified and no unique file path
                 # return filepath of the actual dataset for MEG/EEG/iEEG data
                 if self.suffix is None or self.suffix in ALLOWED_DATATYPES:

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -1142,8 +1142,11 @@ def read_raw_bids(
         del extra_params["exclude"]
         logger.info('"exclude" parameter is not supported by read_raw_bids')
 
-    if raw_path.suffix == ".fif" and "allow_maxshield" not in extra_params:
-        extra_params["allow_maxshield"] = True
+    if raw_path.suffix == ".fif":
+        if "allow_maxshield" not in extra_params:
+            extra_params["allow_maxshield"] = True
+        if "on_split_missing" not in extra_params:
+            extra_params["on_split_missing"] = "warn"
     raw = _read_raw(
         raw_path,
         electrode=None,


### PR DESCRIPTION
## Summary

- `read_raw_bids` crashes when reading FIFF data split across multiple files if not all splits are present. This is documented by a `FIXME` comment in `path.py:905`.
- Pass `on_split_missing="warn"` (available since MNE 0.22) as a default for `.fif` files, alongside the existing `allow_maxshield=True` default.
- Users can still override via `extra_params={"on_split_missing": "raise"}`.
- Updated the FIXME comment in path.py to reflect the partial fix.

Closes #19

## Test plan

- [ ] Run `make pep` and `make test`